### PR TITLE
adding log group for datadog agent

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,16 @@ resource "aws_ecs_cluster" "ecs_cluster" {
   name = "${var.app_name}-${var.environment}"
 }
 
+resource "aws_cloudwatch_log_group" "datadog_log_group" {
+  count = var.create_datadog ? 1 : 0
+  name = "${var.app_name}-${var.environment}-datadog-agent"
+
+  tags = {
+    Environment = var.environment
+    Application = var.app_name
+  }
+}
+
 resource "aws_ecs_service" "main" {
   name = "${var.app_name}-${var.environment}"
   cluster             = aws_ecs_cluster.ecs_cluster.id

--- a/templates/containers.json
+++ b/templates/containers.json
@@ -29,7 +29,7 @@
         "logConfiguration" : {
             "logDriver" : "awslogs",
             "options" : {
-                "awslogs-group" : "${log_group}",
+                "awslogs-group" : "${name}-datadog-agent",
                 "awslogs-region" : "${region}",
                 "awslogs-stream-prefix" : "${awslogs-stream-prefix}"
             }


### PR DESCRIPTION
Adding log group for datadog agent to pull out his logs from application logs.
Subscription for datadog forwarder will be only for application logs.
If any1 want to see agent logs should go to AWS console.