### PR TITLE
Cpu calculation change

### DIFF
--- a/auto_scaling.tf
+++ b/auto_scaling.tf
@@ -1,6 +1,6 @@
 resource "aws_appautoscaling_target" "appautoscaling_target" {
   # if auto-scaling is enabled, than create the resource
-  count = var.is_auto_scaling_enabled ? 1 : 0
+  count              = var.is_auto_scaling_enabled ? 1 : 0
 
   max_capacity       = var.autoscaling_max_capacity
   min_capacity       = var.autoscaling_min_capacity
@@ -11,7 +11,7 @@ resource "aws_appautoscaling_target" "appautoscaling_target" {
 
 resource "aws_appautoscaling_policy" "ecs_auto_scaling" {
   # if auto-scaling is enabled, than create the resource
-  count = var.is_auto_scaling_enabled ? 1 : 0
+  count              = var.is_auto_scaling_enabled ? 1 : 0
 
   name               = "${var.app_name}-${var.environment}_auto_scaling_policy"
   policy_type        = "TargetTrackingScaling"

--- a/auto_scaling.tf
+++ b/auto_scaling.tf
@@ -20,7 +20,9 @@ resource "aws_appautoscaling_policy" "ecs_auto_scaling" {
   service_namespace  = aws_appautoscaling_target.appautoscaling_target[0].service_namespace
 
   target_tracking_scaling_policy_configuration {
-    target_value = var.autoscaling_cpu_target_percentage
+    target_value       = var.autoscaling_cpu_target_percentage
+    scale_in_cooldown  = var.scale_in_cooldown
+    scale_out_cooldown = var.scale_out_cooldown
     predefined_metric_specification {
       predefined_metric_type = "ECSServiceAverageCPUUtilization"
     }

--- a/data.tf
+++ b/data.tf
@@ -32,7 +32,7 @@ data "template_file" "default-container" {
     region                = data.aws_region.current.name
     log_group             = var.aws_cloudwatch_log_group_name
     cpu                   = var.task_definition_cpu - var.datadog_container_cpu
-    memory                = var.app_container_memory - var.datadog_container_memoryreservation
+    memory                = var.app_container_memory
     container_port        = var.app_container_port
     dockerLabels          = local.dockerLabels == "{}" ? "null" : local.dockerLabels
     task_execution_role   = aws_iam_role.ecs_task_execution_role.arn

--- a/data.tf
+++ b/data.tf
@@ -31,7 +31,7 @@ data "template_file" "default-container" {
   vars = {
     region                = data.aws_region.current.name
     log_group             = var.aws_cloudwatch_log_group_name
-    cpu                   = var.app_container_cpu
+    cpu                   = var.task_definition_cpu - var.datadog_container_cpu
     memory                = var.app_container_memory
     container_port        = var.app_container_port
     dockerLabels          = local.dockerLabels == "{}" ? "null" : local.dockerLabels

--- a/data.tf
+++ b/data.tf
@@ -32,7 +32,7 @@ data "template_file" "default-container" {
     region                = data.aws_region.current.name
     log_group             = var.aws_cloudwatch_log_group_name
     cpu                   = var.task_definition_cpu - var.datadog_container_cpu
-    memory                = var.app_container_memory
+    memory                = var.app_container_memory - var.datadog_container_memoryreservation
     container_port        = var.app_container_port
     dockerLabels          = local.dockerLabels == "{}" ? "null" : local.dockerLabels
     task_execution_role   = aws_iam_role.ecs_task_execution_role.arn

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "iam_role_additional_policies" {
 variable "task_definition_cpu" {
   description = "Task definition CPU"
   type        = number
-  default     = 2048
+  default     = 1024
 }
 
 variable "task_definition_memory" {
@@ -75,7 +75,7 @@ variable "task_definition_memory" {
 variable "app_container_cpu" {
   description = "Default container cpu"
   type        = number
-  default     = 2
+  default     = 512
 }
 
 variable "app_container_memory" {
@@ -198,4 +198,16 @@ variable "is_auto_scaling_enabled" {
   description = "A boolean flag to enable/disable auto-scaling features"
   type        = bool
   default     = false
+}
+
+variable "scale_in_cooldown" {
+  description = "Amount of time, in seconds, after a scale in activity completes before another scale in activity can start."
+  type = number
+  default = 15
+}
+
+variable "scale_out_cooldown" {
+  description = "Amount of time, in seconds, after a scale out activity completes before another scale out activity can start."
+  type = number
+  default = 300
 }


### PR DESCRIPTION
- added scale in and scale out attributes
- application container cpu is total task cpu minus datadog container cpu
- task_definition_cpu reduced from 2048 to 1024